### PR TITLE
Adding github workflow to generate pdf

### DIFF
--- a/.github/workflows/generate_pdf.yml
+++ b/.github/workflows/generate_pdf.yml
@@ -1,0 +1,44 @@
+name: generate-pdf
+
+on:
+  push:
+    branches: [ "master" ]
+    paths:
+      - 'PDL/**'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    # ubuntu-slim only uses 1 CPU and 5GB RAM, ubuntu-latest has 4 CPUs and 16GB RAM
+    runs-on: ubuntu-slim
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      - name: Setup Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: "5.28"
+          # install-modules-with: cpanm # installs your cpanfile
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y texlive-extra-utils
+          cpanm --sudo -v --installdeps --notest --cpanfile cpanfile .
+
+      - name: Write POD as PDF and jam them together
+        run: |
+          ./make_chapters.pl
+          ./make_endpieces.pl
+          pdfjam -o PDL_Book.pdf FrontPage.pdf toc.pdf Chapter??.pdf
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: PDL-Book
+          path: PDL_Book.pdf
+          retention-days: 3

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,16 @@
+requires 'perl' => '5.006';
+
+requires 'App::pod2pdf';
+requires 'File::Type';
+requires 'Getopt::Long';
+requires 'Image::Size';
+requires 'PDF::API2';
+requires 'Pod::Checker';
+requires 'Pod::Parser';
+requires 'Pod::Usage';
+
+on 'develop' => sub {
+  requires 'perl' => '5.020';
+
+  requires 'File::Find'; # for the pre-commit hook
+};


### PR DESCRIPTION
This addresses #2 

I've tried to make a bare-bones workflow that uses few resources. It will trigger on a push to the master branch or on a manual trigger in the Github Actions menu. The run took 3m 40s. Because retaining artifacts can have an impact on organization costs, I've dropped the retention from 90 days default to 3 days. You can see the process log and artifact produced (this one retained 5 days) at https://github.com/duffee/pdl-book/actions/runs/26768959131/job/78902919258

PDL-Book is a zip file that contains PDL_Book.pdf and looks how I'd expect.

This is my first workflow, so comments welcome, especially if there is a lighter version of pdfjam. I'm installing the perl dependencies after the apt-get update/install so that I can say `--notest`, but the commented line in Setup Perl would do the same thing. 